### PR TITLE
Add CFEngine policy to fix sshd configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update
 RUN apt-get install cfengine-community
 
 # install cfe-docker process management policy
-RUN wget --no-check-certificate https://github.com/estenberg/cfe-docker/archive/master.zip -P /tmp/ && unzip /tmp/master.zip -d /tmp/
+RUN wget --no-check-certificate https://github.com/zzamboni/cfe-docker/archive/master.zip -P /tmp/ && unzip /tmp/master.zip -d /tmp/
 RUN cp /tmp/cfe-docker-master/cfengine/bin/* /var/cfengine/bin/
 RUN cp /tmp/cfe-docker-master/cfengine/inputs/* /var/cfengine/inputs/
 RUN rm -rf /tmp/cfe-docker-master /tmp/master.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update
 RUN apt-get install cfengine-community
 
 # install cfe-docker process management policy
-RUN wget --no-check-certificate https://github.com/zzamboni/cfe-docker/archive/master.zip -P /tmp/ && unzip /tmp/master.zip -d /tmp/
+RUN wget --no-check-certificate https://github.com/estenberg/cfe-docker/archive/master.zip -P /tmp/ && unzip /tmp/master.zip -d /tmp/
 RUN cp /tmp/cfe-docker-master/cfengine/bin/* /var/cfengine/bin/
 RUN cp /tmp/cfe-docker-master/cfengine/inputs/* /var/cfengine/inputs/
 RUN rm -rf /tmp/cfe-docker-master /tmp/master.zip

--- a/cfengine/inputs/promises.cf
+++ b/cfengine/inputs/promises.cf
@@ -1,7 +1,10 @@
 body common control
 {
-inputs => { "processes.cf" };
-bundlesequence =>  { "processes" };
+inputs => { "/var/cfengine/masterfiles/lib/3.5/files.cf",
+            "/var/cfengine/masterfiles/lib/3.5/common.cf",
+            "ssh.cf",
+            "processes.cf" };
+bundlesequence =>  { "ssh", "processes" };
 }
 
 

--- a/cfengine/inputs/ssh.cf
+++ b/cfengine/inputs/ssh.cf
@@ -1,0 +1,9 @@
+bundle agent ssh
+{
+  vars:
+      "ssh_param[PermitRootLogin]" string => "yes";
+
+  files:
+      "/etc/ssh/sshd_config"
+        edit_line => set_config_values("ssh.ssh_param");
+}


### PR DESCRIPTION
Recent versions of OpenSSH by default do not allow root login using passwords, which breaks the demo by now allowing you to login to the container. So we add CFEngine policy to fix the ssh configuration to allow such logins.
